### PR TITLE
Add IRAC 2026 abstract submission

### DIFF
--- a/pages/irac-2026.md
+++ b/pages/irac-2026.md
@@ -11,6 +11,14 @@ The **5th International Radar Aeroecology Conference (IRAC 2026)** will be held 
 {:.alert .alert-info}
 All conference updates will be communicated via the [Radar Aeroecology mailing list](https://groups.google.com/g/radar-aeroecology). Please sign up to get notifications. [Contact us](irac2026@uva.nl) if you cannot sign up to Google Groups.
 
+## Abstract submission
+
+You can now submit an abstract for an oral presentation or poster at the conference. Abstracts will be reviewed by the scientific committee and you will be informed whether your abstract was accepted. We will not publish conference proceedings, but accepted abstracts will be published on this conference website.
+
+**Submission deadline: xx xx 2026**
+
+[Submit your abstract](https://forms.gle/1whd8Q5Kga73AU2F6){:.btn .btn-primary}
+
 <!-- Thematic sessions -->
 
 <!-- Keynote speakers -->


### PR DESCRIPTION
Hey Bart, here's a start to add the abstract submission button to the IRAC 2026 website. Please update the text as you see fit. After your review, just merge and it will go live.