### PR TITLE
Update registration status for IRAC 2026

### DIFF
--- a/pages/irac-2026.md
+++ b/pages/irac-2026.md
@@ -32,9 +32,9 @@ We thank the following organizations for providing financial support:
 
 ## Registration
 
-[Register for the conference](https://www.aanmelder.nl/irac2026/registration){:.btn .btn-primary}
+Due to overwhelming interest we have reached capacity for the rooms reserved, and therefore registration is currently closed. We are unable to accept additional participants at this time.
 
-Registration deadline: **March 20** for presenting authors. April 28 for other participants.
+If you would like to be placed on the reserve (waiting) list, please send an email to <irac2026@uva.nl>.
 
 ## Venue, travel and accommodation
 


### PR DESCRIPTION
Updated registration information to indicate that registration is closed due to capacity.