### PR TITLE
Add session chairs to program page

### DIFF
--- a/pages/irac-2026.md
+++ b/pages/irac-2026.md
@@ -70,7 +70,7 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 1 - Migration ecology of birds
 
-*Session chair: Maja Bradarić*
+_Session chair: Maja Bradarić_
 
 09:15-09:45 | **[Carrie Ann Adams](abstracts/#caad)** - Fog and blue content of artificial light mediate bird attraction during nocturnal migration **keynote**{:.badge .text-bg-danger}
 09:45-10:00 | **[Benjamin Van Doren](abstracts/#beva)** - Integrating BirdFlow into BirdCast migration alerts: Towards species-specific risk
@@ -81,7 +81,7 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 2 - Methodological advances
 
-*Session chair: Yuting Deng*
+_Session chair: Yuting Deng_
 
 11:15-11:30 | **[Raphaël Nussbaumer](abstracts/#ranu)** - Three-dimensional reconstruction of bird density using inverse weather radar modeling
 11:30-11:45 | **[V. Alistair Drake](abstracts/#vadr)** - What can and cannot be inferred from single- and multiple-point observations of ‘migration in progress’?
@@ -96,7 +96,7 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 3 - Observing insects at scale
 
-*Session chair: Øyvind Nyheim*
+_Session chair: Øyvind Nyheim_
 
 14:00-14:15 | **Anjita Neelatt Anilkumar** - Advancing Desert Locust Surveillance Through Doppler Weather Radar Observations
 14:15-14:30 | **[Ryan R. Neely III](abstracts/#mamu)** - Seeing insects at scale: Weather radar insights from the UK & India
@@ -123,7 +123,7 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 4 - Migration ecology of birds (cont.)
 
-*Session chair: Yuval Werber*
+_Session chair: Yuval Werber_
 
 16:00-16:15 | **[Shannon Curley](abstracts/#shcu)** - Analysis of aerofauna movement using Canadian S-band weather radar
 16:15-16:30 | **[Fengyi Guo](abstracts/#fegu)** - Long-term trends in migratory landbird stopover distribution following 13 years of changes in the contiguous United States
@@ -143,7 +143,7 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 5 - Insect migration
 
-*Session chair: Boya Gao*
+_Session chair: Boya Gao_
 
 09:00-09:30 | **[Nir Sapir](abstracts/#nisa)** - Active navigation and meteorological selectivity drive insect migration patterns through the Levant **keynote**{:.badge .text-bg-danger}
 09:30-09:45 | **[Shannon Mason](abstracts/#shma)** - Serendipitous detections from EarthCARE Cloud Profiling Radar provide first global climatologies of flying insects
@@ -154,7 +154,7 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 6 - Radar applications in wind energy
 
-*Session chair: Fengyi Guo*
+_Session chair: Fengyi Guo_
 
 11:00-11:15 | **[Jill Shephard](abstracts/#jish)** - Integration of bird radar, visual observation and acoustic recordings to inform collision risk modelling of bird species in a remote site in the Pilbara, Western Australia
 11:15-11:30 | **[Erik Fritz](abstracts/#erfr)** - Bird migration over the North Sea: Integrating radar and camera data to assess avian interactions with offshore wind farms
@@ -170,7 +170,7 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 7 - Applications in radar aeroecology
 
-*Session chair: Bart Hoekstra*
+_Session chair: Bart Hoekstra_
 
 14:00-14:30 | **[Jeffrey Buler](abstracts/#jebu)** - WaterFowl Alert Network: Predicting waterfowl distributions within major flyways of the USA from models trained on weather surveillance radar data **keynote**{:.badge .text-bg-danger}
 14:30-14:45 | **[Reuben O'Connell-Booth](abstracts/#reoc)** - No effect of agri-environment schemes on radar-measured aerial insect abundance at landscape scale in England
@@ -187,7 +187,7 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 8 - Movement ecology of bats and insects
 
-*Session chair: Ksenia Kravchenko*
+_Session chair: Ksenia Kravchenko_
 
 09:00-09:30 | **[Silvia Giuntini](abstracts/#sigi)** - Assessing migratory bat movements across seasons and years in Central Europe using vertical-looking radar and acoustic monitoring **keynote**{:.badge .text-bg-danger}
 09:30-09:45 | **[Yuval Werber](abstracts/#yuwe)** - Millions of bats migrate along two continental flyways in Europe and the Middle East
@@ -200,7 +200,7 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 9 - Monitoring the airspace
 
-*Session chair: Yohan Sassi*
+_Session chair: Yohan Sassi_
 
 11:00-11:15 | **[Cecilia Nilsson](abstracts/#ceni)** - Animal niches in the airspace
 11:15-11:30 | **[Dylan Osterhaus](abstracts/#dyos)** - Seeing double: Concurrent dual-frequency observations of aerial migration with CSU-CHILL

--- a/pages/irac-2026.md
+++ b/pages/irac-2026.md
@@ -70,6 +70,8 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 1 - Migration ecology of birds
 
+*Session chair: Maja Bradarić*
+
 09:15-09:45 | **[Carrie Ann Adams](abstracts/#caad)** - Fog and blue content of artificial light mediate bird attraction during nocturnal migration **keynote**{:.badge .text-bg-danger}
 09:45-10:00 | **[Benjamin Van Doren](abstracts/#beva)** - Integrating BirdFlow into BirdCast migration alerts: Towards species-specific risk
 10:00-10:15 | **[Hwayeon Kang](abstracts/#hwka)** - Long-term phenology shifts and barrier-driven weather selective departure decisions in nocturnal bird migration over South Korea
@@ -78,6 +80,8 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 10:45-11:15 | Coffee break
 
 #### Session 2 - Methodological advances
+
+*Session chair: Yuting Deng*
 
 11:15-11:30 | **[Raphaël Nussbaumer](abstracts/#ranu)** - Three-dimensional reconstruction of bird density using inverse weather radar modeling
 11:30-11:45 | **[V. Alistair Drake](abstracts/#vadr)** - What can and cannot be inferred from single- and multiple-point observations of ‘migration in progress’?
@@ -91,6 +95,8 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 12:30-14:00 | Lunch break
 
 #### Session 3 - Observing insects at scale
+
+*Session chair: Øyvind Nyheim*
 
 14:00-14:15 | **Anjita Neelatt Anilkumar** - Advancing Desert Locust Surveillance Through Doppler Weather Radar Observations
 14:15-14:30 | **[Ryan R. Neely III](abstracts/#mamu)** - Seeing insects at scale: Weather radar insights from the UK & India
@@ -117,6 +123,8 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 4 - Migration ecology of birds (cont.)
 
+*Session chair: Yuval Werber*
+
 16:00-16:15 | **[Shannon Curley](abstracts/#shcu)** - Analysis of aerofauna movement using Canadian S-band weather radar
 16:15-16:30 | **[Fengyi Guo](abstracts/#fegu)** - Long-term trends in migratory landbird stopover distribution following 13 years of changes in the contiguous United States
 16:30-16:45 | **[Bart Hoekstra](abstracts/#baho)** - Simulation-informed migration forecasting to improve and understand predictions of rare migration peaks
@@ -135,6 +143,8 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 5 - Insect migration
 
+*Session chair: Boya Gao*
+
 09:00-09:30 | **[Nir Sapir](abstracts/#nisa)** - Active navigation and meteorological selectivity drive insect migration patterns through the Levant **keynote**{:.badge .text-bg-danger}
 09:30-09:45 | **[Shannon Mason](abstracts/#shma)** - Serendipitous detections from EarthCARE Cloud Profiling Radar provide first global climatologies of flying insects
 09:45-10:00 | **[Elske Tielens](abstracts/#elti)** - Large scale insect migration: the role of seasonal and latitudinal pressures
@@ -143,6 +153,8 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 10:30-11:00 | Coffee break
 
 #### Session 6 - Radar applications in wind energy
+
+*Session chair: Fengyi Guo*
 
 11:00-11:15 | **[Jill Shephard](abstracts/#jish)** - Integration of bird radar, visual observation and acoustic recordings to inform collision risk modelling of bird species in a remote site in the Pilbara, Western Australia
 11:15-11:30 | **[Erik Fritz](abstracts/#erfr)** - Bird migration over the North Sea: Integrating radar and camera data to assess avian interactions with offshore wind farms
@@ -157,6 +169,8 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 12:30-14:00 | Lunch break
 
 #### Session 7 - Applications in radar aeroecology
+
+*Session chair: Bart Hoekstra*
 
 14:00-14:30 | **[Jeffrey Buler](abstracts/#jebu)** - WaterFowl Alert Network: Predicting waterfowl distributions within major flyways of the USA from models trained on weather surveillance radar data **keynote**{:.badge .text-bg-danger}
 14:30-14:45 | **[Reuben O'Connell-Booth](abstracts/#reoc)** - No effect of agri-environment schemes on radar-measured aerial insect abundance at landscape scale in England
@@ -173,6 +187,8 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 
 #### Session 8 - Movement ecology of bats and insects
 
+*Session chair: Ksenia Kravchenko*
+
 09:00-09:30 | **[Silvia Giuntini](abstracts/#sigi)** - Assessing migratory bat movements across seasons and years in Central Europe using vertical-looking radar and acoustic monitoring **keynote**{:.badge .text-bg-danger}
 09:30-09:45 | **[Yuval Werber](abstracts/#yuwe)** - Millions of bats migrate along two continental flyways in Europe and the Middle East
 09:45-10:00 | **[Trish Fleming](abstracts/#trfl)** - Quantifying bat flight heights
@@ -183,6 +199,8 @@ Times are indicated in local times for Amsterdam, Netherlands (CEST, UTC+02:00).
 10:30-11:00 | Coffee break
 
 #### Session 9 - Monitoring the airspace
+
+*Session chair: Yohan Sassi*
 
 11:00-11:15 | **[Cecilia Nilsson](abstracts/#ceni)** - Animal niches in the airspace
 11:15-11:30 | **[Dylan Osterhaus](abstracts/#dyos)** - Seeing double: Concurrent dual-frequency observations of aerial migration with CSU-CHILL


### PR DESCRIPTION
Insert session chair lines into pages/irac-2026.md for Sessions 1–9 to clarify moderators for each session. Added italicized "Session chair: ..." entries for Maja Bradarić, Yuting Deng, Øyvind Nyheim, Yuval Werber, Boya Gao, Fengyi Guo, Bart Hoekstra, Ksenia Kravchenko, and Yohan Sassi to improve schedule readability.